### PR TITLE
Add lookup by email

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See https://www.terraform.io/docs/configuration/providers.html#third-party-plugi
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= v0.12.0 (v0.11.x may work but not supported actively)
-- Scope: `users:read,usergroups:read,usergroups:write,channels:read,channels:write,groups:read,groups:write` ref [bot.d/src/bot.ts](./bot.d/src/bot.ts)
+- Scope: `users:read,users:read.email,usergroups:read,usergroups:write,channels:read,channels:write,groups:read,groups:write` ref [bot.d/src/bot.ts](./bot.d/src/bot.ts)
 
 ## Limitations
 

--- a/bot.d/src/bot.ts
+++ b/bot.d/src/bot.ts
@@ -14,6 +14,7 @@ const adapter = new SlackAdapter({
         'usergroups:read',
         'usergroups:write',
         'users:read',
+        'users:read.email',
         'channels:read',
         'channels:write',
         'groups:read',

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -13,6 +13,11 @@ data "slack_user" "sample_2" {
   query_value = var.example_data_user_name
 }
 
+data "slack_user" "sample_3" {
+  query_type  = "email"
+  query_value = var.example_data_user_email
+}
+
 data "slack_channel" "existing_sample_1" {
   channel_id = var.example_data_channel_id
 }

--- a/examples/paid-feature/main.tf
+++ b/examples/paid-feature/main.tf
@@ -17,6 +17,11 @@ data "slack_user" "sample_2" {
   query_value = var.example_data_user_name
 }
 
+data "slack_user" "sample_3" {
+  query_type  = "name"
+  query_value = var.example_data_user_email
+}
+
 resource "slack_usergroup" "new" {
   handle = "zz_terraform_example_new_${var.salt}"
   name   = "New usergroup for terraform example ${var.salt}"

--- a/examples/paid-feature/variables.tf
+++ b/examples/paid-feature/variables.tf
@@ -10,6 +10,10 @@ variable "example_data_user_name" {
   type = string
 }
 
+variable "example_data_user_email" {
+  type = string
+}
+
 variable "example_data_channel_id" {
   type = string
 }

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -10,6 +10,10 @@ variable "example_data_user_name" {
   type = string
 }
 
+variable "example_data_user_email" {
+  type = string
+}
+
 variable "example_data_channel_id" {
   type = string
 }


### PR DESCRIPTION
* Fixes #20 
* As per slack API, the user list method already has email: https://api.slack.com/methods/users.list. We use `data slack_user` to find the user ID of hundreds of slack users, so doing a `lookupByEmail` call for each data resource exhausts our quota pretty fast. Hence reusing the already existing cached logic to reduce number of calls to a predictable minimum
* API token needs `users:read.email` permission