### PR TITLE
fix error when usergroup already removed (disabled)

### DIFF
--- a/slack/resource_usergroup.go
+++ b/slack/resource_usergroup.go
@@ -165,7 +165,9 @@ func resourceSlackUserGroupDelete(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Deleting usergroup: %s", id)
 	if _, err := client.DisableUserGroupContext(ctx, id); err != nil {
-		return err
+		if err.Error() != "already_disabled" {
+			return err
+		}
 	}
 
 	d.SetId("")


### PR DESCRIPTION
# Summary
This PR fixes an error when usergroup is already removed (disabled)

## Before fix:
```
Terraform will perform the following actions:

  # slack_usergroup.test_group will be destroyed
  - resource "slack_usergroup" "test_group" {
      - handle  = "billtestgroup" -> null
      - id      = "xxxx" -> null
      - name    = "billtestgroup" -> null
      - team_id = "T0256J926" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

slack_usergroup.test_group: Destroying... [id=xxxx]

Error: already_disabled
```

## After Fix:
```
Terraform will perform the following actions:

  # slack_usergroup.test_group will be destroyed
  - resource "slack_usergroup" "test_group" {
      - handle  = "billtestgroup" -> null
      - id      = "xxxx" -> null
      - name    = "billtestgroup" -> null
      - team_id = "T0256J926" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

slack_usergroup.test_group: Destroying... [id=xxxx]
slack_usergroup.test_group: Destruction complete after 0s

Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
```
