### PR TITLE
[Fix] Using TypeSet for usergroup memebers

### DIFF
--- a/slack/resource_usergroup_members.go
+++ b/slack/resource_usergroup_members.go
@@ -29,7 +29,7 @@ func resourceSlackUserGroupMembers() *schema.Resource {
 				Required: true,
 			},
 			"members": {
-				Type: schema.TypeList,
+				Type: schema.TypeSet,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},


### PR DESCRIPTION
Since slack doesnt return the members in a consistent order of members, but it remains the same set of members, so using `TypeSet` to avoid diffs like 
```
  ~ resource "slack_usergroup_members" "slack_microservice_usergroup_members" {
        id           = "S01AAXXXXX"
      ~ members      = [
          - "WNF9XXXXX",
            "WNF8XXXXX",
          + "WNF9XXXXX",
            "WNG7XXXXX",
            "WNM2XXXXX",
        ]
        usergroup_id = "S01AAXXXXX"
    }
```