### PR TITLE
fix error when creating group

### DIFF
--- a/slack/resource_usergroup_members.go
+++ b/slack/resource_usergroup_members.go
@@ -51,9 +51,9 @@ func resourceSlackUserGroupMembersCreate(d *schema.ResourceData, meta interface{
 
 	usergroupId := d.Get("usergroup_id").(string)
 
-	iMembers := d.Get("members").([]interface{})
-	userIds := make([]string, len(iMembers))
-	for i, v := range iMembers {
+	iMembers := d.Get("members").(*schema.Set)
+	userIds := make([]string, len(iMembers.List()))
+	for i, v := range iMembers.List() {
 		userIds[i] = v.(string)
 	}
 	userIdParam := strings.Join(userIds, ",")
@@ -112,9 +112,9 @@ func resourceSlackUserGroupMembersUpdate(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	iMembers := d.Get("members").([]interface{})
-	userIds := make([]string, len(iMembers))
-	for i, v := range iMembers {
+	iMembers := d.Get("members").(*schema.Set)
+	userIds := make([]string, len(iMembers.List()))
+	for i, v := range iMembers.List() {
 		userIds[i] = v.(string)
 	}
 	userIdParam := strings.Join(userIds, ",")

--- a/slack/resource_usergroup_members_test.go
+++ b/slack/resource_usergroup_members_test.go
@@ -1,0 +1,204 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/slack-go/slack"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func respondJson(w http.ResponseWriter, r *http.Request, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	b, _ := json.Marshal(data)
+	w.Write(b)
+}
+
+func stringInSlice(slice []string, val string) bool {
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}
+
+type userGroupResponse struct {
+	slack.SlackResponse
+	UserGroup slack.UserGroup `json:"usergroup"`
+}
+
+type userGroupUsersListResponse struct {
+	slack.SlackResponse
+	Users []string `json:"users"`
+}
+
+var testUserGroup = slack.UserGroup{
+	ID:    "S0615G0KT",
+	Users: []string{"U0614TZR7", "U060RNRCZ"},
+}
+
+func Test_ResourceUserGroupMembersRead(t *testing.T) {
+	d := resourceSlackUserGroupMembers().TestResourceData()
+	m := http.NewServeMux()
+	m.HandleFunc("/usergroups.users.list", func(w http.ResponseWriter, r *http.Request) {
+		response := userGroupUsersListResponse{
+			slack.SlackResponse{Ok: true},
+			testUserGroup.Users,
+		}
+		respondJson(w, r, response)
+	})
+	ts := httptest.NewServer(m)
+
+	slackClient := slack.New("test_token",
+		slack.Option(slack.OptionHTTPClient(ts.Client())),
+		slack.OptionAPIURL(ts.URL+"/"))
+
+	team := &Team{slackClient, context.Background()}
+
+	if err := resourceSlackUserGroupMembersRead(d, team); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	members := d.Get("members").(*schema.Set)
+	if len(testUserGroup.Users) != members.Len() {
+		t.Fatalf("expect %v members but got %v", len(testUserGroup.Users), members.Len())
+	}
+	for _, m := range members.List() {
+		if !stringInSlice(testUserGroup.Users, m.(string)) {
+			t.Fatalf("unexpected user ID %s", m)
+		}
+	}
+}
+
+func Test_ResourceUserGroupMembersCreate(t *testing.T) {
+	d := resourceSlackUserGroupMembers().TestResourceData()
+	m := http.NewServeMux()
+
+	newMembers := &schema.Set{F: schema.HashString}
+	for _, u := range testUserGroup.Users {
+		newMembers.Add(u)
+	}
+	if err := d.Set("members", newMembers); err != nil {
+		t.Fatalf("err setting existing members: %s", err)
+	}
+	m.HandleFunc("/usergroups.users.update", func(w http.ResponseWriter, r *http.Request) {
+		response := userGroupResponse{
+			slack.SlackResponse{Ok: true},
+			testUserGroup,
+		}
+		respondJson(w, r, response)
+	})
+	ts := httptest.NewServer(m)
+
+	slackClient := slack.New("test_token",
+		slack.Option(slack.OptionHTTPClient(ts.Client())),
+		slack.OptionAPIURL(ts.URL+"/"))
+
+	team := &Team{slackClient, context.Background()}
+
+	if err := resourceSlackUserGroupMembersCreate(d, team); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	members := d.Get("members").(*schema.Set)
+	if len(testUserGroup.Users) != members.Len() {
+		t.Fatalf("expect %v members but got %v", len(testUserGroup.Users), members.Len())
+	}
+	for _, m := range members.List() {
+		if !stringInSlice(testUserGroup.Users, m.(string)) {
+			t.Fatalf("unexpected user ID %s", m)
+		}
+	}
+}
+
+func Test_ResourceUserGroupMembersUpdate(t *testing.T) {
+	d := resourceSlackUserGroupMembers().TestResourceData()
+	m := http.NewServeMux()
+	d.SetId(testUserGroup.ID)
+	if err := d.Set("usergroup_id", testUserGroup.ID); err != nil {
+		t.Fatalf("err set usergroup_id: %s", err)
+	}
+	existingMembers := &schema.Set{F: schema.HashString}
+	for _, u := range testUserGroup.Users {
+		existingMembers.Add(u)
+	}
+	if err := d.Set("members", existingMembers); err != nil {
+		t.Fatalf("err setting existing members: %s", err)
+	}
+
+	m.HandleFunc("/usergroups.enable", func(w http.ResponseWriter, r *http.Request) {
+		response := userGroupResponse{
+			slack.SlackResponse{Ok: true},
+			testUserGroup,
+		}
+		respondJson(w, r, response)
+	})
+	newTestUserGroup := testUserGroup
+	newTestUserGroup.Users = append(newTestUserGroup.Users, "NUSERID")
+
+	m.HandleFunc("/usergroups.users.update", func(w http.ResponseWriter, r *http.Request) {
+		response := userGroupResponse{
+			slack.SlackResponse{Ok: true},
+			newTestUserGroup,
+		}
+		respondJson(w, r, response)
+	})
+	ts := httptest.NewServer(m)
+
+	slackClient := slack.New("test_token",
+		slack.Option(slack.OptionHTTPClient(ts.Client())),
+		slack.OptionAPIURL(ts.URL+"/"))
+
+	team := &Team{slackClient, context.Background()}
+
+	if err := resourceSlackUserGroupMembersUpdate(d, team); err != nil {
+		t.Fatalf("err update usergroup: %s", err)
+	}
+
+	members := d.Get("members").(*schema.Set)
+	if len(newTestUserGroup.Users) != members.Len() {
+		t.Fatalf("expect %v members but got %v", len(newTestUserGroup.Users), members.Len())
+	}
+	for _, m := range members.List() {
+		if !stringInSlice(newTestUserGroup.Users, m.(string)) {
+			t.Fatalf("unexpected user ID %s", m)
+		}
+	}
+}
+
+func Test_ResourceUserGroupMembersDelete(t *testing.T) {
+	d := resourceSlackUserGroupMembers().TestResourceData()
+	m := http.NewServeMux()
+	d.SetId(testUserGroup.ID)
+	if err := d.Set("usergroup_id", testUserGroup.ID); err != nil {
+		t.Fatalf("err set usergroup_id: %s", err)
+	}
+
+	m.HandleFunc("/usergroups.disable", func(w http.ResponseWriter, r *http.Request) {
+		response := userGroupResponse{
+			slack.SlackResponse{Ok: true},
+			testUserGroup,
+		}
+		respondJson(w, r, response)
+	})
+
+	ts := httptest.NewServer(m)
+
+	slackClient := slack.New("test_token",
+		slack.Option(slack.OptionHTTPClient(ts.Client())),
+		slack.OptionAPIURL(ts.URL+"/"))
+
+	team := &Team{slackClient, context.Background()}
+
+	if err := resourceSlackUserGroupMembersDelete(d, team); err != nil {
+		t.Fatalf("err update usergroup: %s", err)
+	}
+
+	if d.Id() != "" {
+		t.Fatalf("expect id to be empty, but got %s", d.Id())
+	}
+
+}


### PR DESCRIPTION
sorry didnt catch this bug when updating member to TypeSet: https://github.com/jmatsu/terraform-provider-slack/pull/34

```
panic: interface conversion: interface {} is *schema.Set, not []interface {}

goroutine 50 [running]:
github.com/jmatsu/terraform-provider-slack/slack.resourceSlackUserGroupMembersCreate(0xc0002ce8c0, 0xf01ae0, 0xc000510480, 0x2, 0x1c66180)
	/go/src/github.com/jmatsu/terraform-provider-slack/slack/resource_usergroup_members.go:54 +0x577
github.com/hashicorp/terraform/helper/schema.(*Resource).Apply(0xc000140e00, 0xc0003b83c0, 0xc0000d8d60, 0xf01ae0, 0xc000510480, 0xc000480901, 0xc0002123d8, 0xf8eec0)
	/go/pkg/mod/github.com/hashicorp/terraform@v0.12.13/helper/schema/resource.go:305 +0x3b4
github.com/hashicorp/terraform/helper/schema.(*Provider).Apply(0xc000141080, 0xc0002a1a30, 0xc0003b83c0, 0xc0000d8d60, 0xc000512988, 0xc000168030, 0xf91020)
	/go/pkg/mod/github.com/hashicorp/terraform@v0.12.13/helper/schema/provider.go:289 +0x18f
github.com/hashicorp/terraform/helper/plugin.(*GRPCProviderServer).ApplyResourceChange(0xc0000cea10, 0x13f46e0, 0xc0004801e0, 0xc000460060, 0xc0000cea10, 0xc0004801e0, 0xc000210ba8)
	/go/pkg/mod/github.com/hashicorp/terraform@v0.12.13/helper/plugin/grpc_provider.go:885 +0x894
github.com/hashicorp/terraform/internal/tfplugin5._Provider_ApplyResourceChange_Handler(0x10d0100, 0xc0000cea10, 0x13f46e0, 0xc0004801e0, 0xc0003b80f0, 0x0, 0x13f46e0, 0xc0004801e0, 0xc0004ae180, 0xb6)
	/go/pkg/mod/github.com/hashicorp/terraform@v0.12.13/internal/tfplugin5/tfplugin5.pb.go:3189 +0x23e
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000a9080, 0x1400700, 0xc0000a9e00, 0xc0004aa000, 0xc000148420, 0x1c3a8a0, 0x0, 0x0, 0x0)
	/go/pkg/mod/google.golang.org/grpc@v1.21.1/server.go:998 +0x470
google.golang.org/grpc.(*Server).handleStream(0xc0000a9080, 0x1400700, 0xc0000a9e00, 0xc0004aa000, 0x0)
	/go/pkg/mod/google.golang.org/grpc@v1.21.1/server.go:1278 +0xda6
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0000c2370, 0xc0000a9080, 0x1400700, 0xc0000a9e00, 0xc0004aa000)
	/go/pkg/mod/google.golang.org/grpc@v1.21.1/server.go:717 +0x9f
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/go/pkg/mod/google.golang.org/grpc@v1.21.1/server.go:715 +0xa1
```

Also added tests for usergroup members to avoid this from happening, the tests can be improved I think, but I'd also like to add tests for others as well in the future, so will improve along the way.