### PR TITLE
Allow users to choose which change should happen to channels when destroying them

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 
 This is a [Terraform](https://www.terraform.io/) provider for [Slack](https://slack.com)
 
-## Maintainers
-
-@jmatsu, @billcchung
-
 # Installation
 
 ref: https://registry.terraform.io/providers/jmatsu/slack/latest
@@ -31,7 +27,7 @@ See https://www.terraform.io/docs/configuration/providers.html#third-party-plugi
 
 ## Limitations
 
-**I do not have any Plus or Enterprise Grid workspace which I'm free to use unfortunately.**
+**I do not have any Plus or Enterprise Grid workspace which I'm free to use, unfortunately.**
 
 That's why several resources, e.g. a slack user, have not been supported yet. 
 
@@ -61,6 +57,7 @@ resource "slack_conversation" "..." {
   name = "<name>"
   topic = "..."
   purpose = "..."
+  action_on_destroy = "<archive|none>" # this is required since v0.8.0
   is_archive = <true|false>
   is_private = <true|false>
 }
@@ -107,3 +104,7 @@ git push "v$version"
 ## LICENSE
 
 Under [MIT](./LICENSE)
+
+## Maintainers
+
+@jmatsu, @billcchung

--- a/slack/resource_channel.go
+++ b/slack/resource_channel.go
@@ -40,9 +40,9 @@ func resourceSlackChannel() *schema.Resource {
 				Default:  false,
 			},
 			"action_on_destroy": {
-				Type:     schema.TypeString,
-				Description: "Either of none or archive. Be careful if you choose 'archive' because Slack doesn't allow duplicated channel names even if it has been archived.",
-				Required: true,
+				Type:         schema.TypeString,
+				Description:  "Either of none or archive. Be careful if you choose 'archive' because Slack doesn't allow duplicated channel names even if it has been archived.",
+				Required:     true,
 				ValidateFunc: validateConversationActionOnDestroyValue,
 			},
 			"is_shared": {

--- a/slack/resource_channel.go
+++ b/slack/resource_channel.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"context"
+	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/slack-go/slack"
 	"log"
@@ -37,6 +38,12 @@ func resourceSlackChannel() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+			},
+			"action_on_destroy": {
+				Type:     schema.TypeString,
+				Description: "Either of none or archive. Be careful if you choose 'archive' because Slack doesn't allow duplicated channel names even if it has been archived.",
+				Required: true,
+				ValidateFunc: validateConversationActionOnDestroyValue,
 			},
 			"is_shared": {
 				Type:     schema.TypeBool,
@@ -174,10 +181,20 @@ func resourceSlackChannelDelete(d *schema.ResourceData, meta interface{}) error 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	id := d.Id()
 
-	log.Printf("[DEBUG] Deleting(archive) Channel: %s (%s)", id, d.Get("name"))
+	action := d.Get("action_on_destroy").(string)
 
-	if err := client.ArchiveChannelContext(ctx, id); err != nil {
-		return err
+	switch action {
+	case conversationActionOnDestroyNone:
+		log.Printf("[DEBUG] Do nothing on Channel: %s (%s)", id, d.Get("name"))
+	case conversationActionOnDestroyArchive:
+		log.Printf("[DEBUG] Deleting(archive) Channel: %s (%s)", id, d.Get("name"))
+		if err := client.ArchiveChannelContext(ctx, id); err != nil {
+			if err.Error() != "already_archived" {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("unknown action was provided. (%s)", action)
 	}
 
 	d.SetId("")

--- a/slack/resource_channel.go
+++ b/slack/resource_channel.go
@@ -41,7 +41,7 @@ func resourceSlackChannel() *schema.Resource {
 			},
 			"action_on_destroy": {
 				Type:         schema.TypeString,
-				Description:  "Either of none or archive. Be careful if you choose 'archive' because Slack doesn't allow duplicated channel names even if it has been archived.",
+				Description:  "Either of none or archive",
 				Required:     true,
 				ValidateFunc: validateConversationActionOnDestroyValue,
 			},

--- a/slack/resource_conversation.go
+++ b/slack/resource_conversation.go
@@ -2,10 +2,22 @@ package slack
 
 import (
 	"context"
+	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/slack-go/slack"
 	"log"
 )
+
+const (
+	conversationActionOnDestroyNone = "none"
+	conversationActionOnDestroyArchive = "archive"
+)
+
+var validateConversationActionOnDestroyValue= validation.StringInSlice([]string {
+	conversationActionOnDestroyNone,
+	conversationActionOnDestroyArchive,
+}, false)
 
 func resourceSlackConversation() *schema.Resource {
 	return &schema.Resource{
@@ -39,6 +51,12 @@ func resourceSlackConversation() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+			},
+			"action_on_destroy": {
+				Type:     schema.TypeString,
+				Description: "Either of none or archive. Be careful if you choose 'archive' because Slack doesn't allow duplicated channel names even if it has been archived.",
+				Required: true,
+				ValidateFunc: validateConversationActionOnDestroyValue,
 			},
 			"is_shared": {
 				Type:     schema.TypeBool,
@@ -173,10 +191,20 @@ func resourceSlackConversationDelete(d *schema.ResourceData, meta interface{}) e
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	id := d.Id()
 
-	log.Printf("[DEBUG] Deleting(archive) Conversation: %s (%s)", id, d.Get("name"))
+	action := d.Get("action_on_destroy").(string)
 
-	if err := client.ArchiveConversationContext(ctx, id); err != nil {
-		return err
+	switch action {
+	case conversationActionOnDestroyNone:
+		log.Printf("[DEBUG] Do nothing on Conversation: %s (%s)", id, d.Get("name"))
+	case conversationActionOnDestroyArchive:
+		log.Printf("[DEBUG] Deleting(archive) Conversation: %s (%s)", id, d.Get("name"))
+		if err := client.ArchiveConversationContext(ctx, id); err != nil {
+			if err.Error() != "already_archived" {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("unknown action was provided. (%s)", action)
 	}
 
 	d.SetId("")

--- a/slack/resource_conversation.go
+++ b/slack/resource_conversation.go
@@ -54,7 +54,7 @@ func resourceSlackConversation() *schema.Resource {
 			},
 			"action_on_destroy": {
 				Type:         schema.TypeString,
-				Description:  "Either of none or archive. Be careful if you choose 'archive' because Slack doesn't allow duplicated channel names even if it has been archived.",
+				Description:  "Either of none or archive",
 				Required:     true,
 				ValidateFunc: validateConversationActionOnDestroyValue,
 			},

--- a/slack/resource_conversation.go
+++ b/slack/resource_conversation.go
@@ -10,11 +10,11 @@ import (
 )
 
 const (
-	conversationActionOnDestroyNone = "none"
+	conversationActionOnDestroyNone    = "none"
 	conversationActionOnDestroyArchive = "archive"
 )
 
-var validateConversationActionOnDestroyValue= validation.StringInSlice([]string {
+var validateConversationActionOnDestroyValue = validation.StringInSlice([]string{
 	conversationActionOnDestroyNone,
 	conversationActionOnDestroyArchive,
 }, false)
@@ -53,9 +53,9 @@ func resourceSlackConversation() *schema.Resource {
 				Default:  false,
 			},
 			"action_on_destroy": {
-				Type:     schema.TypeString,
-				Description: "Either of none or archive. Be careful if you choose 'archive' because Slack doesn't allow duplicated channel names even if it has been archived.",
-				Required: true,
+				Type:         schema.TypeString,
+				Description:  "Either of none or archive. Be careful if you choose 'archive' because Slack doesn't allow duplicated channel names even if it has been archived.",
+				Required:     true,
 				ValidateFunc: validateConversationActionOnDestroyValue,
 			},
 			"is_shared": {

--- a/slack/resource_group.go
+++ b/slack/resource_group.go
@@ -47,7 +47,7 @@ func resourceSlackGroup() *schema.Resource {
 			},
 			"action_on_destroy": {
 				Type:         schema.TypeString,
-				Description:  "Either of none or archive. Be careful if you choose 'archive' because Slack doesn't allow duplicated channel names even if it has been archived.",
+				Description:  "Either of none or archive",
 				Required:     true,
 				ValidateFunc: validateConversationActionOnDestroyValue,
 			},

--- a/slack/resource_group.go
+++ b/slack/resource_group.go
@@ -46,9 +46,9 @@ func resourceSlackGroup() *schema.Resource {
 				Default:  false,
 			},
 			"action_on_destroy": {
-				Type:     schema.TypeString,
-				Description: "Either of none or archive. Be careful if you choose 'archive' because Slack doesn't allow duplicated channel names even if it has been archived.",
-				Required: true,
+				Type:         schema.TypeString,
+				Description:  "Either of none or archive. Be careful if you choose 'archive' because Slack doesn't allow duplicated channel names even if it has been archived.",
+				Required:     true,
 				ValidateFunc: validateConversationActionOnDestroyValue,
 			},
 			"is_shared": {


### PR DESCRIPTION
Close #41

A new channel must avoid name conflicts but archiving action on destroy-phase causes the future conflict easily. However,  DELETE API requires an Enterprise Grid plan so it should not be the default behavior.

This PR introduces an `action_on_destroy` field to specify what happens on the destroy phase and requires users to specify the value of `action_on_destroy`. This means a new version cannot avoid breaking changes.
